### PR TITLE
spike: Allow VB.NET copy target code

### DIFF
--- a/src/FlaUInspect/Core/HoverMode.cs
+++ b/src/FlaUInspect/Core/HoverMode.cs
@@ -43,8 +43,9 @@ namespace FlaUInspect.Core
         private void DispatcherTimerTick(object sender, EventArgs e)
         {
             // TODO - Allow chosing the keyboard shortcut
-            //if (System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control) && System.Windows.Input.Keyboard.IsKeyDown(System.Windows.Input.Key.LWin))
-            if (System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control))
+            var stockHover = System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control);
+            var leftWinHover = stockHover && System.Windows.Input.Keyboard.IsKeyDown(System.Windows.Input.Key.LWin);
+            if ((_mv.EnableLeftWinHover &&  leftWinHover) || (stockHover && !_mv.EnableLeftWinHover))
             {
                 var screenPos = Mouse.Position;
                 try

--- a/src/FlaUInspect/Core/HoverMode.cs
+++ b/src/FlaUInspect/Core/HoverMode.cs
@@ -42,7 +42,9 @@ namespace FlaUInspect.Core
 
         private void DispatcherTimerTick(object sender, EventArgs e)
         {
-            if (System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control) && System.Windows.Input.Keyboard.IsKeyDown(System.Windows.Input.Key.LWin))
+            // TODO - Allow chosing the keyboard shortcut
+            //if (System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control) && System.Windows.Input.Keyboard.IsKeyDown(System.Windows.Input.Key.LWin))
+            if (System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control))
             {
                 var screenPos = Mouse.Position;
                 try
@@ -66,6 +68,7 @@ namespace FlaUInspect.Core
                 }
                 catch (UnauthorizedAccessException)
                 {
+                    // TODO - Allow ignoring this warning.
                     string caption = "FlaUInspect - Unauthorized access exception";
                     string message = "You are accessing a protected UI element in hover mode.\nTry to start FlaUInspect as administrator.";
                     MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Warning);
@@ -76,6 +79,7 @@ namespace FlaUInspect.Core
                 }
                 catch (COMException cex)
                 {
+                    // TODO - Log this
                     _mv.ComExceptionDetected = true;
                     //MessageBox.Show(cex.Message, "DispatcherTimeTick caught COM exception. Please refresh inspector", MessageBoxButton.OK, MessageBoxImage.Exclamation);
                 }

--- a/src/FlaUInspect/FlaUInspect.csproj
+++ b/src/FlaUInspect/FlaUInspect.csproj
@@ -178,7 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FlaUI.Core">
-      <Version>3.2.0</Version>
+      <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="FlaUI.UIA2">
       <Version>4.0.0</Version>

--- a/src/FlaUInspect/ViewModels/ElementViewModel.cs
+++ b/src/FlaUInspect/ViewModels/ElementViewModel.cs
@@ -375,7 +375,7 @@ namespace FlaUInspect.ViewModels
                 detailGroups.Add(new DetailGroupViewModel("Toggle Pattern", patternDetails));
             }
 
-            //InvokePattern 
+            // InvokePattern 
             if (allSupportedPatterns.Contains(AutomationElement.Automation.PatternLibrary.InvokePattern))
             {
                 var pattern = AutomationElement.Patterns.Invoke.Pattern;

--- a/src/FlaUInspect/ViewModels/MainViewModel.cs
+++ b/src/FlaUInspect/ViewModels/MainViewModel.cs
@@ -126,7 +126,6 @@ namespace FlaUInspect.ViewModels
             set
             {
                 SetProperty(value);
-                RefreshTree();
             }
         }
 

--- a/src/FlaUInspect/ViewModels/MainViewModel.cs
+++ b/src/FlaUInspect/ViewModels/MainViewModel.cs
@@ -69,6 +69,30 @@ namespace FlaUInspect.ViewModels
             private set { SetProperty(value); }
         }
 
+        public bool EnableLeftWinHover
+        {
+            get { return GetProperty<bool>(); }
+            set
+            {
+                if (SetProperty(value))
+                {
+                    Configuration config = ConfigurationManager.OpenExeConfiguration(System.Windows.Forms.Application.ExecutablePath);
+                    config.AppSettings.Settings.Remove("EnableLeftWinHover");
+                    if (value)
+                    {
+                        config.AppSettings.Settings.Add("EnableLeftWinHover", "true");
+                        _hoverMode.Start();
+                    }
+                    else
+                    {
+                        config.AppSettings.Settings.Add("EnableLeftWinHover", "false");
+                        _hoverMode.Stop();
+                    }
+                    config.Save(ConfigurationSaveMode.Minimal);
+                }
+            }
+        }
+
         public bool EnableHoverMode
         {
             get { return GetProperty<bool>(); }
@@ -102,6 +126,7 @@ namespace FlaUInspect.ViewModels
             set
             {
                 SetProperty(value);
+                RefreshTree();
             }
         }
 
@@ -203,10 +228,14 @@ namespace FlaUInspect.ViewModels
             ComExceptionDetected = false;
             // Set modes from config file
             var enableHoverMode = ConfigurationManager.AppSettings["EnableHoverMode"];
+            // TODO - Allow this to be a custom key chord?
+            var enableLeftWinHover = ConfigurationManager.AppSettings["EnableLeftWinHover"];
             var enableFocusTrackingMode = ConfigurationManager.AppSettings["EnableFocusTrackingMode"];
             var enableXPath = ConfigurationManager.AppSettings["EnableXPath"];
 
+            // TODO - Proper string comparison
             EnableHoverMode = enableHoverMode == "true";
+            EnableLeftWinHover = enableLeftWinHover == "true";
             EnableFocusTrackingMode = enableFocusTrackingMode == "true";
             EnableXPath = enableXPath == "true";
         }

--- a/src/FlaUInspect/Views/MainWindow.xaml
+++ b/src/FlaUInspect/Views/MainWindow.xaml
@@ -43,11 +43,12 @@
                     <MenuItem Header="E_xit" Click="MenuItem_Click" />
                 </MenuItem>
                 <MenuItem Header="_Mode">
-                    <MenuItem Header="H_over Mode (use Ctrl + LWin)" IsCheckable="True" IsChecked="{Binding EnableHoverMode}" />
+                    <MenuItem Header="H_over Mode" IsCheckable="True" IsChecked="{Binding EnableHoverMode}"/>
+                    <MenuItem Header="Use Ctrl+LWin" IsCheckable="True" IsChecked="{Binding EnableLeftWinHover}"/>
+
                     <MenuItem Header="_Focus Tracking" IsCheckable="True" IsChecked="{Binding EnableFocusTrackingMode}" />
                     <MenuItem Header="Show _XPath" IsCheckable="True" IsChecked="{Binding EnableXPath}" />
-                    <MenuItem Header="Options" IsCheckable="True" IsChecked="{Binding EnableXPath}" />
-                    
+                    <MenuItem Header="Options" IsCheckable="False" />
                 </MenuItem>
             </Menu>
             <StatusBar DockPanel.Dock="Bottom">

--- a/src/FlaUInspect/Views/MainWindow.xaml
+++ b/src/FlaUInspect/Views/MainWindow.xaml
@@ -46,6 +46,8 @@
                     <MenuItem Header="H_over Mode (use Ctrl + LWin)" IsCheckable="True" IsChecked="{Binding EnableHoverMode}" />
                     <MenuItem Header="_Focus Tracking" IsCheckable="True" IsChecked="{Binding EnableFocusTrackingMode}" />
                     <MenuItem Header="Show _XPath" IsCheckable="True" IsChecked="{Binding EnableXPath}" />
+                    <MenuItem Header="Options" IsCheckable="True" IsChecked="{Binding EnableXPath}" />
+                    
                 </MenuItem>
             </Menu>
             <StatusBar DockPanel.Dock="Bottom">
@@ -92,7 +94,7 @@
                         </TreeView.ItemContainerStyle>
                         <TreeView.ItemTemplate>
                             <HierarchicalDataTemplate ItemsSource="{Binding Children}" DataType="{x:Type models:Element}">
-                                <StackPanel Orientation="Horizontal">
+                                <StackPanel Orientation="Horizontal" MouseRightButtonUp="StackPanel_MouseRightButtonUp">
                                     <Image Width="16" Height="16" Margin="0,0,5,0">
                                         <Image.Style>
                                             <Style TargetType="{x:Type Image}">

--- a/src/FlaUInspect/Views/MainWindow.xaml.cs
+++ b/src/FlaUInspect/Views/MainWindow.xaml.cs
@@ -97,5 +97,144 @@ namespace FlaUInspect.Views
                 });
             }
         }
+
+        private void StackPanel_MouseRightButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // TODO - We should make this language flexible, as well as other configurable text
+            // TODO - Have option to copy relevant extension method
+            // _window.FindFirstDescendant(Function(x) x.ByNameOrAutomationId("")).AsButton()
+            var boundItem = ((sender as StackPanel)?.DataContext as ElementViewModel);
+            string automationNameQuery = "";
+            if (boundItem != null)
+            {
+                automationNameQuery = boundItem.AutomationId ?? boundItem.Name ?? "";
+                var codeString = $"_window.FindFirstDescendant(Function(x) x.ByNameOrAutomationId(\"{automationNameQuery}\"))";
+                // If known type, parse that and return
+                string asTypeCall = GetTypeCall(boundItem);
+                if (!string.IsNullOrWhiteSpace(asTypeCall))
+                    codeString = $"{codeString}.{asTypeCall}()";
+
+                Clipboard.SetText(codeString);
+            }
+        }
+
+        private static string GetTypeCall(ElementViewModel boundItem)
+        {
+            var asTypeCall = "";
+            switch (boundItem.ControlType)
+            {
+                case FlaUI.Core.Definitions.ControlType.Button:
+                    asTypeCall = "AsButton";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Unknown:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.AppBar:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Calendar:
+                    asTypeCall = "AsCalendar";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.CheckBox:
+                    asTypeCall = "AsCheckBox";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ComboBox:
+                    asTypeCall = "AsComboBox";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Custom:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.DataGrid:
+                    asTypeCall = "AsDataGridView";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.DataItem:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Document:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Edit:
+                    asTypeCall = "AsTextBox";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Group:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Header:
+                    asTypeCall = "AsGridHeader";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.HeaderItem:
+                    asTypeCall = "AsGridHeaderItem";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Hyperlink:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Image:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.List:
+                    asTypeCall = "AsListBox";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ListItem:
+                    asTypeCall = "AsListBoxItem";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.MenuBar:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Menu:
+                    asTypeCall = "AsMenu";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.MenuItem:
+                    asTypeCall = "AsMenuItem";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Pane:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ProgressBar:
+                    asTypeCall = "AsProgressBar";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.RadioButton:
+                    asTypeCall = "AsRadioButton";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ScrollBar:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.SemanticZoom:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Separator:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Slider:
+                    asTypeCall = "AsSlider";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Spinner:
+                    asTypeCall = "AsSpinner";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.SplitButton:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.StatusBar:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Tab:
+                    asTypeCall = "AsTab";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.TabItem:
+                    asTypeCall = "AsTabItem";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Table:
+                    asTypeCall = "AsGrid";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Text:
+                    asTypeCall = "AsLabel";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Thumb:
+                    asTypeCall = "AsThumb";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.TitleBar:
+                    asTypeCall = "AsTitleBar";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ToolBar:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.ToolTip:
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Tree:
+                    asTypeCall = "AsTree";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.TreeItem:
+                    asTypeCall = "AsTreeItem";
+                    break;
+                case FlaUI.Core.Definitions.ControlType.Window:
+                    asTypeCall = "AsWindow";
+                    break;
+            }
+
+            return asTypeCall;
+        }
     }
 }


### PR DESCRIPTION
Goal here is to support right-clicking on the relevant control in the tree view, and copying a simple selection code snippet to the clipboard. There's a template extension method the user will need to add to their code, but that simplifies the generated strings substantially.